### PR TITLE
Remove 'Roblox setup for distro'

### DIFF
--- a/Maliks_Roblox_Wrapper.sh
+++ b/Maliks_Roblox_Wrapper.sh
@@ -345,8 +345,6 @@ select fav in "${distros[@]}"; do
 
         "Install Roblox")
 
-read -p "Roblox setup for $distro_guess Linux. Close all web browsers then press Return key to start . . ."
-
 full_setup
 
 		exit


### PR DESCRIPTION
This isn't really needed anymore and will produce the same result without it.